### PR TITLE
[FIXED] Output array img is incompatible

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -40,7 +40,7 @@ def saveResult(img_file, img, boxes, dirname='./result/', verticals=None, texts=
         Return:
             None
         """
-        img = np.array(img)
+        img = np.ascontiguousarray(img, dtype=np.uint8)
 
         # make result file list
         filename, file_ext = os.path.splitext(os.path.basename(img_file))


### PR DESCRIPTION
Was getting this error before:
cv2.polylines(img, [poly.reshape((-1, 1, 2))], True, color=(0, 0, 255), thickness=2)
TypeError: Layout of the output array img is incompatible with cv::Mat (step[ndims-1] != elemsize or step[1] != elemsize*nchannels)

Fixed by changing line 43 of file_utils.py, as suggested by @gvdsand in an issue post.