### PR TITLE
fix: remove zero boxes after detection

### DIFF
--- a/craft_utils.py
+++ b/craft_utils.py
@@ -73,8 +73,9 @@ def getDetBoxes_core(textmap, linkmap, text_threshold, link_threshold, low_text)
         box = np.roll(box, 4-startidx, 0)
         box = np.array(box)
 
-        det.append(box)
-        mapper.append(k)
+        if np.count_nonzero(box) != 0:
+            det.append(box)
+            mapper.append(k)
 
     return det, labels, mapper
 


### PR DESCRIPTION
The CRAFT text detection produced false positive detections under some condition (e.g. with text_threshold = 0.01, link_threshold = 0.01, low_text = 0.1 and my pictures). 

While most of the predicted text boxes are correct, there are wrong predictions containing only zero values (screenshot showes print of 4 predicted boxes and there are 2 wrong boxes only with zeros as values).
![Zero Boxes problem](https://github.com/clovaai/CRAFT-pytorch/assets/142549018/7f91c5a7-4098-4f92-bdbf-ce134631d1a3)

That can lead to an error within the craft module depending on the OpenCV version.
I recognized the following error with opencv-python-4.5.4.60:
cv2.error: OpenCV(4.5.4) matrix.cpp:466: error: (-215:Assertion failed) _step >= minstep in function 'cv::Mat::Mat'

To fix that problem, I added a check to remove the zero boxes for further steps 
