### PR TITLE
Fix: Resolves memory leak caused by using CRAFT detector repeatedly

### DIFF
--- a/test.py
+++ b/test.py
@@ -84,6 +84,9 @@ def test_net(net, image, text_threshold, link_threshold, low_text, cuda, poly, r
     with torch.no_grad():
         y, feature = net(x)
 
+    # remove X from device memory, no longer needed
+    del x
+    
     # make score and link map
     score_text = y[0,:,:,0].cpu().data.numpy()
     score_link = y[0,:,:,1].cpu().data.numpy()
@@ -94,6 +97,12 @@ def test_net(net, image, text_threshold, link_threshold, low_text, cuda, poly, r
             y_refiner = refine_net(y, feature)
         score_link = y_refiner[0,:,:,0].cpu().data.numpy()
 
+
+    # remove y and feature from device, whether GPU or CPU
+    del y, feature
+    # empty cuda cache to allow nvidia-smi to be more accurate
+    torch.cuda.empty_cache()
+    
     t0 = time.time() - t0
     t1 = time.time()
 

--- a/test.py
+++ b/test.py
@@ -101,7 +101,8 @@ def test_net(net, image, text_threshold, link_threshold, low_text, cuda, poly, r
     # remove y and feature from device, whether GPU or CPU
     del y, feature
     # empty cuda cache to allow nvidia-smi to be more accurate
-    torch.cuda.empty_cache()
+    if cuda:
+        torch.cuda.empty_cache()
     
     t0 = time.time() - t0
     t1 = time.time()


### PR DESCRIPTION
This fix enables garbage collection to appropriately work when https://github.com/clovaai/CRAFT-pytorch/blob/e332dd8b718e291f51b66ff8f9ef2c98ee4474c8/test.py#L69 returns, by deleting `x` we moved to the GPU after we move the forward pass results back to the CPU. Likewise, the same in deleting `y` and `feature` after they are no longer needed.

See https://pytorch.org/blog/understanding-gpu-memory-2/#why-doesnt-automatic-garbage-collection-work for more detail.

Running `torch.cuda.empty_cache()` in `test_net()` before returning allows nvidia-smi to be accurate.

**Relevant package versions**
torch version 2.2.1+cu121
torchvision 0.17.1+cu121

Hope this helps!