### PR TITLE
Fix issue #194: Added dtype as object to polys array in adjustResultCoordinates

### DIFF
--- a/craft_utils.py
+++ b/craft_utils.py
@@ -236,7 +236,7 @@ def getDetBoxes(textmap, linkmap, text_threshold, link_threshold, low_text, poly
 
 def adjustResultCoordinates(polys, ratio_w, ratio_h, ratio_net = 2):
     if len(polys) > 0:
-        polys = np.array(polys)
+        polys = np.array(polys, dtype=object)
         for k in range(len(polys)):
             if polys[k] is not None:
                 polys[k] *= (ratio_w * ratio_net, ratio_h * ratio_net)


### PR DESCRIPTION
### Description

This pull request fixes issue #194 by adding `dtype=object` when creating the `polys` array in the `adjustResultCoordinates()` function. This change allows the creation of arrays with incompatible types, addressing the error that was previously occurring.

### Changes Made:
- Modified the `polys` array creation to use `dtype=object`.

### Issue:
Fixes #194

